### PR TITLE
Add VppNamedMessage trait implementation to all messages

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,10 +67,12 @@ pub fn derive_message(input: proc_macro::TokenStream) -> proc_macro::TokenStream
                 })
              }
          }
-         impl #name {
-            pub fn get_message_name_and_crc() -> String {
+        impl VppNamedMessage for #name {
+            fn get_message_name_and_crc() -> String {
                  String::from(#ident)
             }
+        }
+         impl #name {
             pub fn builder() -> #builder_ident{
                 #builder_ident{
                  #(#builder_init,)*


### PR DESCRIPTION
This goes along with another PR to the generator to add this trait.

By defining this as a trait, we can simplify the calling code, and simply call this method from inside our send_recv* functions.

Unfortunately both of these PRs depend on each other.  The other is https://github.com/ayourtch/vpp-api-gen/pull/21